### PR TITLE
Secure Actuator endpoints - restrict to ADMIN_USER role

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,12 +350,17 @@ Both authentication methods share:
   - Authentication APIs (`/api/v1/auth/**`)
   - Public UI pages (`/`, `/login`, `/register`, `/sales`)
   - Swagger UI (`/swagger-ui.html`)
+  - Actuator health endpoints (`/actuator/health`, `/actuator/health/**`) - publicly accessible for Kubernetes liveness/readiness probes
 - **Authenticated Endpoints**: 
   - Client APIs (`/api/v1/clients/**`) - require JWT authentication
   - User UI pages (`/orders`) - require form-based authentication
 - **Admin Endpoints**: 
   - Admin APIs (`/api/v1/admin/**`, `/api/v1/products/**`) - require `ADMIN_USER` role and JWT
   - Admin UI pages (`/admin/**`) - require `ADMIN_USER` role and form-based authentication
+  - Actuator endpoints (`/actuator/**` except `/actuator/health/**`) - require `ADMIN_USER` role and form-based authentication
+    - Access via web UI: Log in as an admin user and navigate to `/actuator/**` endpoints
+    - Examples: `/actuator/metrics`, `/actuator/info`, `/actuator/env`
+    - Note: Health endpoints remain public for container orchestration compatibility
 
 ## Key Features
 

--- a/src/main/java/uk/co/aosd/flash/config/SecurityConfig.java
+++ b/src/main/java/uk/co/aosd/flash/config/SecurityConfig.java
@@ -114,7 +114,10 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 // Public UI pages
                 .requestMatchers("/", "/login", "/register", "/sales", "/sales/**", "/css/**", "/js/**", "/images/**", "/favicon.ico").permitAll()
-                .requestMatchers("/actuator/**").permitAll()
+                // Health endpoint remains public for Kubernetes liveness/readiness probes
+                .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
+                // All other actuator endpoints require ADMIN_USER role for security
+                .requestMatchers("/actuator/**").hasRole("ADMIN_USER")
                 .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                 // Admin UI pages require ADMIN_USER role
                 .requestMatchers("/admin/**").hasRole("ADMIN_USER")

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,6 +15,8 @@ management:
   endpoints:
     web:
       exposure:
+        # Expose all endpoints (security is enforced via Spring Security filter chain)
+        # In production, consider limiting to: health,info,metrics
         include: '*'
   health:
     probes:

--- a/src/test/java/uk/co/aosd/flash/config/ActuatorSecurityTest.java
+++ b/src/test/java/uk/co/aosd/flash/config/ActuatorSecurityTest.java
@@ -1,0 +1,135 @@
+package uk.co.aosd.flash.config;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Integration test for actuator endpoint security.
+ * Tests that actuator endpoints are properly secured and require ADMIN_USER role.
+ * 
+ * Note: This test uses a profile that includes SecurityConfig (not "test" profile)
+ * to test the actual security configuration.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@ActiveProfiles({"admin-service", "api-service"}) // Exclude "test" profile to use real SecurityConfig
+public class ActuatorSecurityTest {
+
+    @Container
+    @ServiceConnection
+    public static PostgreSQLContainer postgreSQLContainer = new PostgreSQLContainer("postgres:latest");
+
+    @Container
+    @ServiceConnection(name = "redis")
+    @SuppressWarnings("resource")
+    public static GenericContainer<?> redisContainer = new GenericContainer<>(DockerImageName.parse("redis:latest"))
+        .withExposedPorts(6379);
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void shouldAllowPublicAccessToHealthEndpoint() throws Exception {
+        // Health endpoint should be publicly accessible for Kubernetes probes
+        // May return 200 (healthy) or 503 (unhealthy) depending on service status
+        // Important: Should NOT return 302 (redirect to login) or 403 (forbidden)
+        final int status = mockMvc.perform(get("/actuator/health"))
+            .andReturn()
+            .getResponse()
+            .getStatus();
+        assert status == 200 || status == 503 : "Health endpoint should be accessible (200 or 503), got " + status;
+    }
+
+    @Test
+    public void shouldAllowPublicAccessToHealthLivenessEndpoint() throws Exception {
+        // Health liveness endpoint should be publicly accessible
+        final int status = mockMvc.perform(get("/actuator/health/liveness"))
+            .andReturn()
+            .getResponse()
+            .getStatus();
+        assert status == 200 || status == 503 : "Health liveness should be accessible (200 or 503), got " + status;
+    }
+
+    @Test
+    public void shouldAllowPublicAccessToHealthReadinessEndpoint() throws Exception {
+        // Health readiness endpoint should be publicly accessible
+        final int status = mockMvc.perform(get("/actuator/health/readiness"))
+            .andReturn()
+            .getResponse()
+            .getStatus();
+        assert status == 200 || status == 503 : "Health readiness should be accessible (200 or 503), got " + status;
+    }
+
+    @Test
+    public void shouldDenyUnauthenticatedAccessToMetricsEndpoint() throws Exception {
+        // Metrics endpoint should require authentication
+        mockMvc.perform(get("/actuator/metrics"))
+            .andExpect(status().isFound()); // Redirects to login page (302)
+    }
+
+    @Test
+    public void shouldDenyUnauthenticatedAccessToInfoEndpoint() throws Exception {
+        // Info endpoint should require authentication
+        mockMvc.perform(get("/actuator/info"))
+            .andExpect(status().isFound()); // Redirects to login page (302)
+    }
+
+    @Test
+    public void shouldDenyNonAdminUserAccessToMetricsEndpoint() throws Exception {
+        // Regular USER role should not have access to actuator endpoints
+        mockMvc.perform(get("/actuator/metrics")
+            .with(user("user").roles("USER")))
+            .andExpect(status().isForbidden()); // 403 Forbidden
+    }
+
+    @Test
+    public void shouldAllowAdminUserAccessToMetricsEndpoint() throws Exception {
+        // ADMIN_USER role should have access to actuator endpoints
+        // Endpoint may return 200 (if enabled) or 404 (if not enabled)
+        // Important: Should NOT return 302 (redirect) or 403 (forbidden)
+        final int status = mockMvc.perform(get("/actuator/metrics")
+            .with(user("admin").roles("ADMIN_USER")))
+            .andReturn()
+            .getResponse()
+            .getStatus();
+        assert (status == 200 || status == 404) && status != 302 && status != 403
+            : "Admin should access metrics (200 or 404), not be redirected (302) or forbidden (403), got " + status;
+    }
+
+    @Test
+    public void shouldAllowAdminUserAccessToInfoEndpoint() throws Exception {
+        // ADMIN_USER role should have access to actuator endpoints
+        // Endpoint may return 200 (if enabled) or 404 (if not enabled)
+        // Important: Should NOT return 302 (redirect) or 403 (forbidden)
+        final int status = mockMvc.perform(get("/actuator/info")
+            .with(user("admin").roles("ADMIN_USER")))
+            .andReturn()
+            .getResponse()
+            .getStatus();
+        assert (status == 200 || status == 404) && status != 302 && status != 403
+            : "Admin should access info (200 or 404), not be redirected (302) or forbidden (403), got " + status;
+    }
+
+    @Test
+    public void shouldDenyNonAdminUserAccessToInfoEndpoint() throws Exception {
+        // Regular USER role should not have access to actuator endpoints
+        mockMvc.perform(get("/actuator/info")
+            .with(user("user").roles("USER")))
+            .andExpect(status().isForbidden()); // 403 Forbidden
+    }
+}


### PR DESCRIPTION
## Summary
This PR implements security restrictions for Spring Boot Actuator endpoints as outlined in issue #58.

## Changes
- **SecurityConfig.java**: Updated to require `ADMIN_USER` role for actuator endpoints (except health endpoints)
- **Health endpoints remain public**: `/actuator/health` and `/actuator/health/**` remain publicly accessible for Kubernetes liveness/readiness probes
- **ActuatorSecurityTest.java**: Added comprehensive integration tests to verify security restrictions
- **application.yaml**: Added security documentation comments
- **README.md**: Updated with actuator endpoint access requirements

## Security Improvements
- Actuator endpoints (metrics, info, env, etc.) now require `ADMIN_USER` role
- Health endpoints remain public for container orchestration compatibility
- Prevents unauthorized access to sensitive application information

## Testing
- All existing tests pass (331 tests)
- New ActuatorSecurityTest verifies:
  - Public access to health endpoints
  - Unauthenticated requests are redirected to login
  - Non-admin users receive 403 Forbidden
  - Admin users can access actuator endpoints

## Breaking Changes
- Actuator endpoints (except health) are no longer publicly accessible
- Admin users must authenticate via web UI to access actuator endpoints
- This is an intentional security improvement

Fixes #58