### PR TITLE
Fix #69: Add configurable CORS for API

### DIFF
--- a/src/main/java/uk/co/aosd/flash/config/CorsConfig.java
+++ b/src/main/java/uk/co/aosd/flash/config/CorsConfig.java
@@ -1,0 +1,33 @@
+package uk.co.aosd.flash.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+/**
+ * CORS configuration for the API. Registers a {@link CorsConfigurationSource}
+ * that applies to {@code /api/**} so cross-origin frontends can call the API.
+ */
+@Configuration
+@EnableConfigurationProperties(CorsProperties.class)
+@Profile("!test")
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource(final CorsProperties properties) {
+        final CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(properties.allowedOrigins());
+        config.setAllowedMethods(properties.allowedMethods());
+        config.setAllowedHeaders(properties.allowedHeaders());
+        config.setAllowCredentials(properties.allowCredentials());
+        config.setMaxAge(properties.maxAge());
+
+        final UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", config);
+        return source;
+    }
+}

--- a/src/main/java/uk/co/aosd/flash/config/CorsProperties.java
+++ b/src/main/java/uk/co/aosd/flash/config/CorsProperties.java
@@ -1,0 +1,19 @@
+package uk.co.aosd.flash.config;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for CORS (Cross-Origin Resource Sharing).
+ * Binds to {@code app.cors.*} in application configuration.
+ */
+@ConfigurationProperties(prefix = "app.cors")
+public record CorsProperties(
+    List<String> allowedOrigins,
+    List<String> allowedMethods,
+    List<String> allowedHeaders,
+    boolean allowCredentials,
+    long maxAge
+) {
+}

--- a/src/main/java/uk/co/aosd/flash/config/SecurityConfig.java
+++ b/src/main/java/uk/co/aosd/flash/config/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.web.cors.CorsConfigurationSource;
 import uk.co.aosd.flash.security.CustomAuthenticationSuccessHandler;
 import uk.co.aosd.flash.security.JwtAuthenticationEntryPoint;
 import uk.co.aosd.flash.security.JwtAuthenticationFilter;
@@ -37,6 +38,7 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomAuthenticationSuccessHandler authenticationSuccessHandler;
+    private final CorsConfigurationSource corsConfigurationSource;
 
     /**
      * Security filter chain for API endpoints (JWT-based, stateless).
@@ -47,6 +49,8 @@ public class SecurityConfig {
     public SecurityFilterChain apiSecurityFilterChain(final HttpSecurity http) throws Exception {
         http
             .securityMatcher("/api/**")
+            // Enable CORS for cross-origin API requests (preflight and actual requests)
+            .cors(cors -> cors.configurationSource(corsConfigurationSource))
             // Disable CSRF for stateless JWT-based API
             .csrf(AbstractHttpConfigurer::disable)
             // Configure stateless session management

--- a/src/main/resources/application-api-service.yaml
+++ b/src/main/resources/application-api-service.yaml
@@ -44,3 +44,21 @@ app:
     min-sale-duration-minutes: 5
   scheduler:
     interval-seconds: 30  # Default: check every 30 seconds
+  cors:
+    # Allowed origins for cross-origin API requests (e.g. SPA frontends).
+    # Override in production with actual frontend origin(s). Avoid '*' with credentials.
+    allowed-origins:
+      - http://localhost:3000
+      - http://127.0.0.1:3000
+    allowed-methods:
+      - GET
+      - POST
+      - PUT
+      - PATCH
+      - DELETE
+      - OPTIONS
+    allowed-headers:
+      - Authorization
+      - Content-Type
+    allow-credentials: true
+    max-age: 3600

--- a/src/test/java/uk/co/aosd/flash/config/CorsConfigTest.java
+++ b/src/test/java/uk/co/aosd/flash/config/CorsConfigTest.java
@@ -1,0 +1,79 @@
+package uk.co.aosd.flash.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Integration test for CORS configuration on API endpoints.
+ * Uses real SecurityConfig and CorsConfig (profiles admin-service, api-service)
+ * to assert that cross-origin requests receive correct CORS headers.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@ActiveProfiles({"admin-service", "api-service"})
+class CorsConfigTest {
+
+    private static final String ALLOWED_ORIGIN = "http://localhost:3000";
+    private static final String DISALLOWED_ORIGIN = "http://disallowed.example.com";
+
+    @Container
+    @ServiceConnection
+    public static PostgreSQLContainer postgreSQLContainer = new PostgreSQLContainer("postgres:latest");
+
+    @Container
+    @ServiceConnection(name = "redis")
+    @SuppressWarnings("resource")
+    public static GenericContainer<?> redisContainer = new GenericContainer<>(DockerImageName.parse("redis:latest"))
+        .withExposedPorts(6379);
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldReturnCorsHeadersForAllowedOriginOnApiRequest() throws Exception {
+        // Unauthenticated request to /api/v1/auth/me returns 401 or 403; we assert CORS header is present
+        mockMvc.perform(get("/api/v1/auth/me").header("Origin", ALLOWED_ORIGIN))
+            .andExpect(header().string("Access-Control-Allow-Origin", ALLOWED_ORIGIN));
+    }
+
+    @Test
+    void shouldReturnCorsHeadersOnPreflightRequestWithoutAuthentication() throws Exception {
+        ResultActions result = mockMvc.perform(
+            options("/api/v1/auth/login")
+                .header("Origin", ALLOWED_ORIGIN)
+                .header("Access-Control-Request-Method", "POST")
+                .header("Access-Control-Request-Headers", "Content-Type"));
+        result
+            .andExpect(status().isOk())
+            .andExpect(header().string("Access-Control-Allow-Origin", ALLOWED_ORIGIN))
+            .andExpect(header().exists("Access-Control-Allow-Methods"))
+            .andExpect(header().exists("Access-Control-Allow-Headers"))
+            .andExpect(header().exists("Access-Control-Max-Age"));
+    }
+
+    @Test
+    void shouldNotExposeAllowOriginForDisallowedOrigin() throws Exception {
+        ResultActions result = mockMvc.perform(get("/api/v1/auth/me").header("Origin", DISALLOWED_ORIGIN));
+        String allowOrigin = result.andReturn().getResponse().getHeader("Access-Control-Allow-Origin");
+        // Disallowed origin must not get Access-Control-Allow-Origin (or must not be the disallowed origin)
+        assert allowOrigin == null || !DISALLOWED_ORIGIN.equals(allowOrigin)
+            : "Disallowed origin must not receive Access-Control-Allow-Origin";
+    }
+}


### PR DESCRIPTION
## Summary
Implements the fix plan from issue #69: add CORS (Cross-Origin Resource Sharing) configuration so frontends from different origins can call the API.

## Changes
- **app.cors** configuration in `application-api-service.yaml`: `allowed-origins`, `allowed-methods`, `allowed-headers`, `allow-credentials`, `max-age` (dev defaults: localhost:3000, 127.0.0.1:3000).
- **CorsProperties** (`@ConfigurationProperties(prefix = "app.cors")`) and **CorsConfig**: `CorsConfigurationSource` bean applied to `/api/**`.
- **SecurityConfig**: API security chain uses `.cors(cors -> cors.configurationSource(corsConfigurationSource))` so preflight (OPTIONS) and actual requests get CORS headers; preflight does not require authentication.
- **CorsConfigTest**: integration test (real SecurityConfig + CorsConfig) asserting:
  - Allowed origin receives `Access-Control-Allow-Origin`.
  - OPTIONS preflight returns 200 with CORS headers without auth.
  - Disallowed origin does not receive `Access-Control-Allow-Origin`.

## Testing
- `mvn test` (full suite) passes.
- CORS behaviour covered by `CorsConfigTest`.