### PR TITLE
Add health checks for external services (fixes #70)

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -152,6 +152,16 @@ Content-Type: application/json
 
 **Note**: The API uses JWT-based authentication (stateless), while the UI uses form-based session authentication (stateful).
 
+## Health and Readiness Probes
+
+The application exposes Spring Boot Actuator health endpoints suitable for Kubernetes liveness and readiness probes:
+
+- **`/actuator/health/liveness`** — Liveness: process is alive (ping only). Use for Kubernetes liveness probes.
+- **`/actuator/health/readiness`** — Readiness: process plus external dependencies (database, Redis, RabbitMQ). Returns 200 when the app can serve traffic; returns 503 if DB, Redis, or RabbitMQ is down. Use for Kubernetes readiness probes.
+- **`/actuator/health`** — Full health (all indicators). Use for debugging; response shows which component failed when unhealthy.
+
+All health endpoints are unauthenticated so orchestrators can probe them without credentials.
+
 ## Accessing Swagger UI
 
 Once the application is running, you can access the interactive API documentation at:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,6 +21,11 @@ management:
   health:
     probes:
       enabled: true
+    group:
+      liveness:
+        include: ping
+      readiness:
+        include: ping,db,redis,rabbit
   endpoint:
     health:
       show-details: always # Optional: helpful for debugging


### PR DESCRIPTION
## Summary
Implements health checks for external services (Redis, RabbitMQ, DB) as described in #70 and the [fix plan comment](https://github.com/twalmsley/FlashSales/issues/70#issuecomment-3816505255).

## Changes
- **Health groups** in `application.yaml`: liveness = `ping` only; readiness = `ping`, `db`, `redis`, `rabbit` so the app is not considered ready until all dependencies are up.
- **ActuatorSecurityTest**: Added RabbitMQ Testcontainer so readiness can return 200 when all services are up; added `shouldReportReadinessUpWhenExternalServicesAreUp` test.
- **GETTING_STARTED.md**: Documented liveness/readiness endpoints and Kubernetes probe usage.

## Testing
- Full test suite passes (`./mvnw test`).
- Readiness returns 503 if any of DB/Redis/Rabbit is down (by design); with all three containers in tests, readiness returns 200/UP.