### PR TITLE
Fix #82: Move RabbitMQ messaging out of OrderService into OrderMessageSender

### DIFF
--- a/src/main/java/uk/co/aosd/flash/controllers/web/ClientWebController.java
+++ b/src/main/java/uk/co/aosd/flash/controllers/web/ClientWebController.java
@@ -20,6 +20,7 @@ import uk.co.aosd.flash.dto.CreateOrderDto;
 import uk.co.aosd.flash.security.CustomUserDetailsService;
 import uk.co.aosd.flash.security.SecurityUtils;
 import uk.co.aosd.flash.services.ActiveSalesService;
+import uk.co.aosd.flash.services.OrderMessageSender;
 import uk.co.aosd.flash.services.OrderService;
 import uk.co.aosd.flash.services.ProductsService;
 
@@ -36,6 +37,7 @@ public class ClientWebController {
     private final ActiveSalesService activeSalesService;
     private final ProductsService productsService;
     private final OrderService orderService;
+    private final OrderMessageSender orderMessageSender;
     private final CustomUserDetailsService userDetailsService;
 
     @GetMapping
@@ -80,6 +82,7 @@ public class ClientWebController {
         try {
             final UUID userId = getCurrentUserId();
             final var order = orderService.createOrder(createOrderDto, userId);
+            orderMessageSender.sendForProcessing(order.orderId());
             redirectAttributes.addFlashAttribute("success", "Order created successfully! Order ID: " + order.orderId());
             return "redirect:/orders";
         } catch (final Exception e) {

--- a/src/main/java/uk/co/aosd/flash/dto/ProcessPaymentResult.java
+++ b/src/main/java/uk/co/aosd/flash/dto/ProcessPaymentResult.java
@@ -1,0 +1,11 @@
+package uk.co.aosd.flash.dto;
+
+import java.util.UUID;
+
+/**
+ * Result of processing an order payment.
+ * Used by callers (e.g. OrderProcessingConsumer) to decide whether to send
+ * dispatch or payment-failed message.
+ */
+public record ProcessPaymentResult(boolean success, UUID orderId) {
+}

--- a/src/main/java/uk/co/aosd/flash/services/OrderMessageSender.java
+++ b/src/main/java/uk/co/aosd/flash/services/OrderMessageSender.java
@@ -1,0 +1,67 @@
+package uk.co.aosd.flash.services;
+
+import java.util.UUID;
+
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+import uk.co.aosd.flash.config.RabbitMQConfig;
+
+/**
+ * Sends order-related messages to RabbitMQ.
+ * Callers invoke this after the transactional service method returns (and thus after commit).
+ */
+@Component
+@RequiredArgsConstructor
+public class OrderMessageSender {
+
+    private static final Logger log = LoggerFactory.getLogger(OrderMessageSender.class);
+
+    private final RabbitTemplate rabbitTemplate;
+
+    /**
+     * Send order for processing (payment).
+     */
+    public void sendForProcessing(final UUID orderId) {
+        rabbitTemplate.convertAndSend(
+            RabbitMQConfig.ORDER_EXCHANGE,
+            RabbitMQConfig.ROUTING_KEY_PROCESSING,
+            orderId.toString());
+        log.info("Queued order {} for processing", orderId);
+    }
+
+    /**
+     * Send order for dispatch.
+     */
+    public void sendForDispatch(final UUID orderId) {
+        rabbitTemplate.convertAndSend(
+            RabbitMQConfig.ORDER_EXCHANGE,
+            RabbitMQConfig.ROUTING_KEY_DISPATCH,
+            orderId.toString());
+        log.info("Queued order {} for dispatch", orderId);
+    }
+
+    /**
+     * Send order for failed payment handling.
+     */
+    public void sendForPaymentFailed(final UUID orderId) {
+        rabbitTemplate.convertAndSend(
+            RabbitMQConfig.ORDER_EXCHANGE,
+            RabbitMQConfig.ROUTING_KEY_PAYMENT_FAILED,
+            orderId.toString());
+        log.info("Queued order {} for failed payment handling", orderId);
+    }
+
+    /**
+     * Send order for refund notification.
+     */
+    public void sendForRefund(final UUID orderId) {
+        rabbitTemplate.convertAndSend(
+            RabbitMQConfig.ORDER_EXCHANGE,
+            RabbitMQConfig.ROUTING_KEY_REFUND,
+            orderId.toString());
+        log.info("Queued order {} for refund notification", orderId);
+    }
+}

--- a/src/test/java/uk/co/aosd/flash/services/OrderMessageSenderTest.java
+++ b/src/test/java/uk/co/aosd/flash/services/OrderMessageSenderTest.java
@@ -1,0 +1,67 @@
+package uk.co.aosd.flash.services;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import uk.co.aosd.flash.config.RabbitMQConfig;
+
+/**
+ * Test OrderMessageSender.
+ */
+public class OrderMessageSenderTest {
+
+    private RabbitTemplate rabbitTemplate;
+    private OrderMessageSender sender;
+
+    @BeforeEach
+    public void beforeEach() {
+        rabbitTemplate = Mockito.mock(RabbitTemplate.class);
+        sender = new OrderMessageSender(rabbitTemplate);
+    }
+
+    @Test
+    public void sendForProcessing_shouldSendToProcessingRoutingKey() {
+        final UUID orderId = UUID.randomUUID();
+        sender.sendForProcessing(orderId);
+        verify(rabbitTemplate).convertAndSend(
+            eq(RabbitMQConfig.ORDER_EXCHANGE),
+            eq(RabbitMQConfig.ROUTING_KEY_PROCESSING),
+            eq(orderId.toString()));
+    }
+
+    @Test
+    public void sendForDispatch_shouldSendToDispatchRoutingKey() {
+        final UUID orderId = UUID.randomUUID();
+        sender.sendForDispatch(orderId);
+        verify(rabbitTemplate).convertAndSend(
+            eq(RabbitMQConfig.ORDER_EXCHANGE),
+            eq(RabbitMQConfig.ROUTING_KEY_DISPATCH),
+            eq(orderId.toString()));
+    }
+
+    @Test
+    public void sendForPaymentFailed_shouldSendToPaymentFailedRoutingKey() {
+        final UUID orderId = UUID.randomUUID();
+        sender.sendForPaymentFailed(orderId);
+        verify(rabbitTemplate).convertAndSend(
+            eq(RabbitMQConfig.ORDER_EXCHANGE),
+            eq(RabbitMQConfig.ROUTING_KEY_PAYMENT_FAILED),
+            eq(orderId.toString()));
+    }
+
+    @Test
+    public void sendForRefund_shouldSendToRefundRoutingKey() {
+        final UUID orderId = UUID.randomUUID();
+        sender.sendForRefund(orderId);
+        verify(rabbitTemplate).convertAndSend(
+            eq(RabbitMQConfig.ORDER_EXCHANGE),
+            eq(RabbitMQConfig.ROUTING_KEY_REFUND),
+            eq(orderId.toString()));
+    }
+}


### PR DESCRIPTION
## Summary
Implements the fix plan for issue #82: send RabbitMQ messages **outside** the transactional service so callers perform "service then send" after commit.

## Changes
- **ProcessPaymentResult** (new DTO): `success`, `orderId` — returned by `processOrderPayment` so callers know whether to send dispatch or payment-failed.
- **OrderMessageSender** (new component): holds `RabbitTemplate`, exposes `sendForProcessing`, `sendForDispatch`, `sendForPaymentFailed`, `sendForRefund`. No transaction logic.
- **OrderService**: removed `RabbitTemplate` and all `TransactionSynchronizationManager` / `TransactionSynchronization` usage. `createOrder`, `processOrderPayment`, `handleRefund` no longer send any RabbitMQ messages. `processOrderPayment` now returns `ProcessPaymentResult`.
- **ClientRestApi**: after successful `createOrder` calls `orderMessageSender.sendForProcessing(response.orderId())`; after `handleRefund` calls `orderMessageSender.sendForRefund(orderUuid)`.
- **ClientWebController**: after successful `createOrder` calls `orderMessageSender.sendForProcessing(order.orderId())`.
- **OrderProcessingConsumer**: calls `result = orderService.processOrderPayment(orderId)`, then `orderMessageSender.sendForDispatch(orderId)` or `sendForPaymentFailed(orderId)` based on `result.success()`.

## Tests
- **OrderServiceTest**: no `RabbitTemplate`/TSM; `processOrderPayment` asserts `ProcessPaymentResult`; createOrder/handleRefund assert notifications only.
- **OrderMessageSenderTest** (new): verifies `convertAndSend` with correct exchange/routing key for each of the four methods.
- **OrderProcessingConsumerTest**: verifies sender called with `sendForDispatch` on success, `sendForPaymentFailed` on failure; no sender call when service throws.
- **ClientRestApiTest**: verifies `orderMessageSender.sendForProcessing` after createOrder, `sendForRefund` after refund.

## Verification
`mvn test` — 340 tests, 0 failures.