### PR TITLE
Fix #89: Order list shows product name; order detail shows product info

### DIFF
--- a/src/main/resources/templates/orders/detail.html
+++ b/src/main/resources/templates/orders/detail.html
@@ -28,6 +28,19 @@
                     <a th:href="@{/orders}" class="btn btn-secondary">Back to Orders</a>
                 </div>
             </div>
+            <div class="card mt-3">
+                <div class="card-body">
+                    <h5 class="card-title">Product Information</h5>
+                    <p class="card-text">
+                        <strong>Product ID:</strong> <span th:text="${order.productId()}">—</span><br>
+                        <strong>Product name:</strong> <span th:text="${order.productName() != null ? order.productName() : '—'}">—</span><br>
+                        <th:block th:if="${order.flashSaleId() != null}">
+                            <strong>Flash sale ID:</strong> <span th:text="${order.flashSaleId()}">—</span><br>
+                            <strong>Flash sale:</strong> <span th:text="${order.flashSaleTitle() != null ? order.flashSaleTitle() : '—'}">—</span>
+                        </th:block>
+                    </p>
+                </div>
+            </div>
         </div>
     </main>
 

--- a/src/main/resources/templates/orders/list.html
+++ b/src/main/resources/templates/orders/list.html
@@ -21,7 +21,7 @@
             <table class="table table-striped">
                 <thead>
                     <tr>
-                        <th>Order ID</th>
+                        <th>Product</th>
                         <th>Status</th>
                         <th>Price</th>
                         <th>Quantity</th>
@@ -32,7 +32,7 @@
                 </thead>
                 <tbody>
                     <tr th:each="order : ${orders}">
-                        <td th:text="${order.orderId()}">Order ID</td>
+                        <td th:text="${order.productName() != null ? order.productName() : '—'}">Product name</td>
                         <td><span class="badge"
                                 th:classappend="${order.status().name() == 'PAID' ? 'bg-success' : (order.status().name() == 'PENDING' ? 'bg-warning' : 'bg-secondary')}"
                                 th:text="${order.status()}">Status</span></td>


### PR DESCRIPTION
## Summary
Implements the fix plan from issue #89.

### Changes
- **Order list** (`/orders`): First column now shows **product name** instead of Order ID; column header renamed to "Product". View link still uses `orderId` for navigation.
- **Order detail** (`/orders/{id}`): Added a **Product Information** card showing product ID, product name, and (when present) flash sale ID and title.

### Implementation
- **`orders/list.html`**: Table header `Order ID` → `Product`; first column `order.orderId()` → `order.productName()` with null-safe fallback `—`.
- **`orders/detail.html`**: New card "Product Information" with `productId`, `productName`, and conditional `flashSaleId` / `flashSaleTitle`.

No Java or repository changes; `OrderDetailDto` and `OrderService` already provide `productName`, `productId`, `flashSaleId`, `flashSaleTitle`.

### Testing
- Full test suite run (`mvn test`); all tests passed.
- Template-only change; no new unit tests added (optional MVC tests noted in issue).