### PR TITLE
Add Maven Release Plugin support (fixes #88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,38 @@ The application includes comprehensive test coverage using Testcontainers for in
 ./mvnw test
 ```
 
+## Releasing
+
+The project uses the [Maven Release Plugin](https://maven.apache.org/maven-release/maven-release-plugin/) to create versioned releases, tag the repository, and publish artifacts.
+
+### Prerequisites
+
+- Clean working tree (no uncommitted changes)
+- Git credentials configured (SSH or token) for pushing and tagging
+- For `release:perform` deploy: GitHub Packages credentials in `~/.m2/settings.xml` (server id `github`) if publishing to GitHub Packages
+
+### Release workflow
+
+1. **Prepare a release** (validates SCM, runs tests, updates POM version, creates tag, commits):
+   ```bash
+   ./mvnw release:prepare
+   ```
+   To validate without committing or tagging:
+   ```bash
+   ./mvnw release:prepare -DdryRun=true
+   ```
+
+2. **Perform the release** (checks out the tag, builds, and deploys artifacts):
+   ```bash
+   ./mvnw release:perform
+   ```
+   To validate deploy configuration without deploying:
+   ```bash
+   ./mvnw release:perform -DdryRun=true
+   ```
+
+The plugin uses tag format `v@{project.version}` (e.g. `v0.0.1`). It does not skip tests by default; ensure the environment (e.g. Testcontainers, ports) is suitable for release runs.
+
 ## License
 
 This is a skills demonstration project.

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<version>0.0.1-SNAPSHOT</version>
 	<name>Flash Sales Demo App</name>
 	<description>Skills demo for Java web app.</description>
-	<url/>
+	<url>https://github.com/twalmsley/FlashSales</url>
 	<licenses>
 		<license/>
 	</licenses>
@@ -21,11 +21,21 @@
 		<developer/>
 	</developers>
 	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
+		<connection>scm:git:https://github.com/twalmsley/FlashSales.git</connection>
+		<developerConnection>scm:git:git@github.com:twalmsley/FlashSales.git</developerConnection>
+		<tag>HEAD</tag>
+		<url>https://github.com/twalmsley/FlashSales</url>
 	</scm>
+	<distributionManagement>
+		<repository>
+			<id>github</id>
+			<url>https://maven.pkg.github.com/twalmsley/FlashSales</url>
+		</repository>
+		<snapshotRepository>
+			<id>github</id>
+			<url>https://maven.pkg.github.com/twalmsley/FlashSales</url>
+		</snapshotRepository>
+	</distributionManagement>
 	<properties>
 		<java.version>25</java.version>
 		<spring-cloud.version>2025.1.0</spring-cloud.version>
@@ -328,6 +338,17 @@
                     <password>password</password>
                 </configuration>
             </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>3.0.0</version>
+				<configuration>
+					<tagNameFormat>v@{project.version}</tagNameFormat>
+					<autoVersionSubmodules>false</autoVersionSubmodules>
+					<pushChanges>true</pushChanges>
+					<localCheckout>true</localCheckout>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
## Summary
Implements the fix plan for issue #88: adds Maven Release Plugin support so `mvn release:prepare` and `mvn release:perform` can be used to create versioned releases, tag the repo, and publish artifacts.

## Changes
- **SCM**: Populated `connection`, `developerConnection`, `tag` (HEAD), and `url` using `twalmsley/FlashSales` (from git remote).
- **distributionManagement**: Added `repository` and `snapshotRepository` for GitHub Packages so `release:perform` can deploy.
- **maven-release-plugin** (3.0.0): Added with `tagNameFormat` `v@{project.version}`, `pushChanges` true, `localCheckout` true, `autoVersionSubmodules` false.
- **Project url**: Set to `https://github.com/twalmsley/FlashSales`.
- **README**: New "Releasing" section with prerequisites, `release:prepare` / `release:perform` usage, and dry-run commands.

## Testing
- `./mvnw test` — full test suite passes (no regressions).
- `release:prepare -DdryRun=true` requires a clean working tree; can be run after merge to validate SCM and plugin config.

Closes #88.