### PR TITLE
Fix #95: Flash sale create UI - date binding and empty products

### DIFF
--- a/src/main/java/uk/co/aosd/flash/config/WebMvcConfig.java
+++ b/src/main/java/uk/co/aosd/flash/config/WebMvcConfig.java
@@ -1,0 +1,90 @@
+package uk.co.aosd.flash.config;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.util.Locale;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Web MVC configuration. Registers formatters and converters for web binding,
+ * including support for HTML5 {@code datetime-local} input values
+ * ({@code yyyy-MM-dd'T'HH:mm} or {@code yyyy-MM-dd'T'HH:mm:ss}) when binding to
+ * {@link OffsetDateTime}.
+ */
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    /** Parses HTML5 datetime-local: yyyy-MM-ddTHH:mm or yyyy-MM-ddTHH:mm:ss (no offset). */
+    private static final DateTimeFormatter DATETIME_LOCAL = new DateTimeFormatterBuilder()
+        .appendPattern("yyyy-MM-dd'T'HH:mm")
+        .optionalStart().appendPattern(":ss").optionalEnd()
+        .toFormatter();
+
+    /** Format for HTML5 datetime-local value (no seconds, no offset). */
+    private static final DateTimeFormatter DATETIME_LOCAL_OUTPUT =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
+
+    @Override
+    public void addFormatters(final FormatterRegistry registry) {
+        registry.addConverter(new StringToOffsetDateTimeConverter());
+        registry.addFormatterForFieldType(OffsetDateTime.class, new OffsetDateTimeFormatter());
+    }
+
+    /**
+     * Formats {@link OffsetDateTime} for HTML5 datetime-local inputs
+     * (yyyy-MM-dd'T'HH:mm in system default zone).
+     */
+    static class OffsetDateTimeFormatter implements org.springframework.format.Formatter<OffsetDateTime> {
+
+        @Override
+        public OffsetDateTime parse(final String text, final Locale locale) {
+            return new StringToOffsetDateTimeConverter().convert(text);
+        }
+
+        @Override
+        public String print(final OffsetDateTime object, final Locale locale) {
+            if (object == null) {
+                return "";
+            }
+            return object.atZoneSameInstant(ZoneId.systemDefault()).format(DATETIME_LOCAL_OUTPUT);
+        }
+    }
+
+    /**
+     * Converts strings to {@link OffsetDateTime}. Accepts:
+     * <ul>
+     *   <li>Full ISO-8601 date-time with offset (e.g. 2026-02-01T09:00:00Z)</li>
+     *   <li>HTML5 datetime-local style without offset (e.g. 2026-02-01T09:00 or 2026-02-01T09:00:00),
+     *       interpreted in the JVM default zone.</li>
+     * </ul>
+     */
+    static class StringToOffsetDateTimeConverter implements Converter<String, OffsetDateTime> {
+
+        @Override
+        public OffsetDateTime convert(final String source) {
+            if (source == null || source.isBlank()) {
+                return null;
+            }
+            final String trimmed = source.trim();
+            try {
+                return OffsetDateTime.parse(trimmed);
+            } catch (final DateTimeParseException ignored) {
+                // Try datetime-local style (no offset)
+            }
+            try {
+                final LocalDateTime local = LocalDateTime.parse(trimmed, DATETIME_LOCAL);
+                return local.atZone(ZoneId.systemDefault()).toOffsetDateTime();
+            } catch (final DateTimeParseException e) {
+                throw new IllegalArgumentException("Cannot parse date-time: " + source, e);
+            }
+        }
+    }
+}

--- a/src/main/java/uk/co/aosd/flash/controllers/web/AdminWebController.java
+++ b/src/main/java/uk/co/aosd/flash/controllers/web/AdminWebController.java
@@ -1,6 +1,7 @@
 package uk.co.aosd.flash.controllers.web;
 
 import java.time.OffsetDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -132,20 +133,25 @@ public class AdminWebController {
         final BindingResult bindingResult,
         final RedirectAttributes redirectAttributes) {
 
+        final CreateSaleDto dto = createSaleDto.products() != null
+            ? createSaleDto
+            : new CreateSaleDto(createSaleDto.id(), createSaleDto.title(), createSaleDto.startTime(),
+                createSaleDto.endTime(), createSaleDto.status(), Collections.emptyList());
+
         if (bindingResult.hasErrors()) {
             redirectAttributes.addFlashAttribute("org.springframework.validation.BindingResult.createSaleDto", bindingResult);
-            redirectAttributes.addFlashAttribute("createSaleDto", createSaleDto);
+            redirectAttributes.addFlashAttribute("createSaleDto", dto);
             return "redirect:/admin/sales/new";
         }
 
         try {
-            final UUID saleId = flashSalesService.createFlashSale(createSaleDto);
+            final UUID saleId = flashSalesService.createFlashSale(dto);
             redirectAttributes.addFlashAttribute("success", "Flash sale created successfully");
             return "redirect:/admin/sales/" + saleId;
         } catch (final Exception e) {
             log.error("Error creating flash sale", e);
             redirectAttributes.addFlashAttribute("error", "Failed to create flash sale: " + e.getMessage());
-            redirectAttributes.addFlashAttribute("createSaleDto", createSaleDto);
+            redirectAttributes.addFlashAttribute("createSaleDto", dto);
             return "redirect:/admin/sales/new";
         }
     }

--- a/src/main/java/uk/co/aosd/flash/dto/CreateSaleDto.java
+++ b/src/main/java/uk/co/aosd/flash/dto/CreateSaleDto.java
@@ -31,7 +31,7 @@ public record CreateSaleDto(
     @NotNull(message = "The sale needs a valid end time.") OffsetDateTime endTime,
     @Schema(description = "Initial sale status.", example = "DRAFT")
     @NotNull(message = "The sale needs a valid status.") SaleStatus status,
-    @Schema(description = "Products to include in the sale, with reserved allocations.")
-    @Valid @NotEmpty(message = "The sale needs at least one product.") List<SaleProductDto> products
+    @Schema(description = "Products to include in the sale, with reserved allocations. May be empty when creating via UI; products can be added after creation.")
+    @Valid List<SaleProductDto> products
 ) implements Serializable {
 }

--- a/src/main/java/uk/co/aosd/flash/services/FlashSalesService.java
+++ b/src/main/java/uk/co/aosd/flash/services/FlashSalesService.java
@@ -24,6 +24,7 @@ import uk.co.aosd.flash.domain.SaleStatus;
 import uk.co.aosd.flash.dto.AddFlashSaleItemDto;
 import uk.co.aosd.flash.dto.CreateSaleDto;
 import uk.co.aosd.flash.dto.FlashSaleItemDto;
+import uk.co.aosd.flash.dto.SaleProductDto;
 import uk.co.aosd.flash.dto.FlashSaleResponseDto;
 import uk.co.aosd.flash.dto.UpdateFlashSaleDto;
 import uk.co.aosd.flash.dto.UpdateFlashSaleItemDto;
@@ -104,8 +105,9 @@ public class FlashSalesService {
             // there is enough.
             final List<String> missingProducts = new ArrayList<>();
             final List<Product> notEnoughStockProducts = new ArrayList<>();
+            final List<SaleProductDto> productList = sale.products() != null ? sale.products() : List.of();
 
-            sale.products().forEach(sp -> {
+            productList.forEach(sp -> {
                 final var maybeProduct = products.findById(UUID.fromString(sp.id()));
                 maybeProduct.ifPresentOrElse(p -> {
                     if (p.getReservedCount() + sp.reservedCount() > p.getTotalPhysicalStock()) {

--- a/src/test/java/uk/co/aosd/flash/controllers/FlashSaleRestApiCreateSaleTest.java
+++ b/src/test/java/uk/co/aosd/flash/controllers/FlashSaleRestApiCreateSaleTest.java
@@ -104,8 +104,7 @@ public class FlashSaleRestApiCreateSaleTest {
             .andExpect(content().string(containsString("A non-empty title is needed for the sale.")))
             .andExpect(content().string(containsString("The sale needs a valid start time.")))
             .andExpect(content().string(containsString("The sale needs a valid end time.")))
-            .andExpect(content().string(containsString("The sale needs a valid status.")))
-            .andExpect(content().string(containsString("The sale needs at least one product.")));
+            .andExpect(content().string(containsString("The sale needs a valid status.")));
 
         verify(salesService, times(0)).createFlashSale(saleDto);
 


### PR DESCRIPTION
Fixes #95

**Problem:** Creating a new flash sale at `/admin/sales/new` failed, likely due to date formatting. The form uses HTML5 `datetime-local` inputs, which submit values like `2026-02-01T14:30` (no timezone/seconds). Spring’s default `OffsetDateTime` binding expects full ISO-8601, so binding failed. The DTO also required at least one product while the UI says products can be added after creation.

**Changes:**
- **WebMvcConfig:** Added `StringToOffsetDateTimeConverter` that accepts both full ISO-8601 and `datetime-local`-style strings (`yyyy-MM-ddTHH:mm` or `yyyy-MM-ddTHH:mm:ss`), interpreting local strings in the JVM default zone.
- **WebMvcConfig:** Added `OffsetDateTimeFormatter` so Thymeleaf renders `OffsetDateTime` as `yyyy-MM-dd'T'HH:mm` for `datetime-local` inputs.
- **CreateSaleDto:** `products` is no longer `@NotEmpty`; sales can be created with no products (products can be added later).
- **AdminWebController:** Normalize `null` `products` to an empty list before validation and service call.
- **FlashSalesService:** Treat `null` `products` as empty list to avoid NPE.
- **Tests:** Removed assertion on "at least one product" in `FlashSaleRestApiCreateSaleTest`; added `AdminWebControllerTest.createSale_withDatetimeLocalFormatAndNoProducts_redirectsToSaleDetail` to cover the UI create flow with `datetime-local` dates and no products.

Full test suite: `mvn test` (green).