### PR TITLE
Add Light/Dark mode toggle with Dark as default (fixes #99)

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -16,3 +16,13 @@ main {
 .card:hover {
     transform: translateY(-5px);
 }
+
+/* Dark mode overrides: footer and custom elements */
+[data-bs-theme="dark"] footer.bg-light {
+    background-color: var(--bs-dark) !important;
+    color: var(--bs-body-color);
+}
+
+[data-bs-theme="dark"] footer .text-muted {
+    color: var(--bs-secondary-color) !important;
+}

--- a/src/main/resources/templates/layout/base.html
+++ b/src/main/resources/templates/layout/base.html
@@ -7,6 +7,12 @@
     <title th:text="${pageTitle != null ? pageTitle + ' - Flash Sales' : 'Flash Sales'}">Flash Sales</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link th:href="@{/css/style.css}" rel="stylesheet">
+    <script>
+      (function(){
+        var theme = localStorage.getItem('flash-theme') || 'dark';
+        document.documentElement.setAttribute('data-bs-theme', theme);
+      })();
+    </script>
 </head>
 
 <body>
@@ -32,6 +38,13 @@
                     </li>
                 </ul>
                 <ul class="navbar-nav">
+                    <li class="nav-item">
+                        <button type="button" class="btn btn-link nav-link border-0 p-0 d-flex align-items-center" id="theme-toggle" aria-label="Switch to light mode" title="Switch to light mode">
+                            <span class="theme-icon" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="1.25em" height="1.25em" fill="currentColor" viewBox="0 0 16 16"><path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6zm0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0zm0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13zm8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5zM3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8zm10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0zm-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707zM4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708z"/></svg>
+                            </span>
+                        </button>
+                    </li>
                     <li class="nav-item" th:if="${session.isAuthenticated == null or !session.isAuthenticated}">
                         <a class="nav-link" th:href="@{/login}">Login</a>
                     </li>
@@ -57,6 +70,37 @@
 
     <div th:fragment="scripts">
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+        <script>
+          (function(){
+            var STORAGE_KEY = 'flash-theme';
+            var sunSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="1.25em" height="1.25em" fill="currentColor" viewBox="0 0 16 16"><path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6zm0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0zm0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13zm8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5zM3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8zm10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0zm-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707zM4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708z"/></svg>';
+            var moonSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="1.25em" height="1.25em" fill="currentColor" viewBox="0 0 16 16"><path d="M6 .278a.768.768 0 0 1 .08.858 7.208 7.208 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.787.787 0 0 1 .81.316.733.733 0 0 1-.031.893A8.349 8.349 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.752.752 0 0 1 6 .278z"/></svg>';
+            function getTheme(){ return document.documentElement.getAttribute('data-bs-theme') || 'dark'; }
+            function setTheme(value){ document.documentElement.setAttribute('data-bs-theme', value); localStorage.setItem(STORAGE_KEY, value); }
+            function updateToggle(){
+              var btn = document.getElementById('theme-toggle');
+              if (!btn) return;
+              var current = getTheme();
+              var next = current === 'dark' ? 'light' : 'dark';
+              btn.setAttribute('aria-label', next === 'light' ? 'Switch to light mode' : 'Switch to dark mode');
+              btn.setAttribute('title', next === 'light' ? 'Switch to light mode' : 'Switch to dark mode');
+              var icon = btn.querySelector('.theme-icon');
+              if (icon) icon.innerHTML = next === 'light' ? sunSvg : moonSvg;
+            }
+            document.addEventListener('DOMContentLoaded', function(){
+              var btn = document.getElementById('theme-toggle');
+              if (btn) {
+                updateToggle();
+                btn.addEventListener('click', function(){
+                  var current = getTheme();
+                  var next = current === 'dark' ? 'light' : 'dark';
+                  setTheme(next);
+                  updateToggle();
+                });
+              }
+            });
+          })();
+        </script>
     </div>
 </body>
 


### PR DESCRIPTION
## Summary
Implements the fix plan from issue #99: adds a UI toggle so users can switch between **Light Mode** and **Dark Mode**, with **Dark Mode** as the default.

## Changes
- **`layout/base.html`**
  - **Head:** Inline script runs before first paint, reads `localStorage.getItem('flash-theme')` (default `'dark'`), sets `data-bs-theme` on `<html>` to avoid flash of wrong theme.
  - **Nav:** Theme toggle button (sun/moon icon) in the right-hand navbar with `id="theme-toggle"`, `aria-label` and `title` for accessibility.
  - **Scripts:** Click handler toggles theme, updates `data-bs-theme`, saves to `localStorage`, and updates button icon/label (sun when in dark mode → switch to light, moon when in light → switch to dark).
- **`static/css/style.css`**
  - Dark mode overrides for footer (`bg-light`) and `.text-muted` so they look correct when `data-bs-theme="dark"`.

## Testing
- `mvn test` — full suite passes.
- Manual: Default is Dark; toggle switches theme and persists across refresh/navigation (as per issue testing strategy).